### PR TITLE
Fix incorrect axis in winrate metric computation

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -608,8 +608,8 @@ def extract_metrics(path, config, verbose=False):
         cav_duration_cols = [f"agent_{id}_duration" for id in CAV_ids if f"agent_{id}_duration" in training_frames.columns]
         human_duration_cols = [f"agent_{id}_duration" for id in human_ids if f"agent_{id}_duration" in training_frames.columns]
         if cav_duration_cols and human_duration_cols:
-            average_time_CAVs = training_frames[cav_duration_cols].mean()
-            average_time_humans = training_frames[human_duration_cols].mean()
+            average_time_CAVs = training_frames[cav_duration_cols].mean(axis=1) # per-episode average for CAV agents
+            average_time_humans = training_frames[human_duration_cols].mean(axis=1) # per-episode average for unmutated human agents
 
             winrate = np.mean((average_time_humans - average_time_CAVs) > 0)
 


### PR DESCRIPTION
### Problem:

The winrate metric was computed using:

   `average_time_CAVs = training_frames[cav_duration_cols].mean()`
   `average_time_humans = training_frames[human_duration_cols].mean()`

Since `cav_duration_cols` and `human_duration_cols` are disjoint column sets,
the default column-wise aggregation (axis=0) produced pandas series with non-overlapping indices.
Their subtraction therefore resulted in an all-NaN series.

**As a consequence:**
    `winrate = np.mean((average_time_humans - average_time_CAVs) > 0)`
always returned 0, independently of the data, without raising an error.<br><br>



### Impact:
This caused the **winrate metric to always evaluate to 0, no matter the underlying data**.
No warning or exception was triggered.


### Fix:
Aggregation is now performed row-wise (axis=1), ensuring correct alignment before comparison.<br><br>

### Check:
Tested on greedy algorithm outputs where winrate is expected to be > 0.<br>