### PR TITLE
save data .2f precision, int32

### DIFF
--- a/analysis/metrics.py
+++ b/analysis/metrics.py
@@ -311,7 +311,9 @@ def collect_to_single_CSV(
         return pd.DataFrame()
     
     df = pd.concat(dfs, axis=0, ignore_index=True)
-    df.to_csv(save_path, index=False)
+    df["episode"] = df["episode"].astype("int32")
+
+    df.to_csv(save_path, index=False, float_format="%.2f")    
 
     return df
 
@@ -712,6 +714,7 @@ def extract_metrics(path, config, verbose=False):
                 "time_excess": float,
             }
         )
+
         if not human_ids:
             vector_metrics_df["instability_humans"] = np.zeros(len(vector_metrics_df), dtype=float)
         if not CAV_ids:


### PR DESCRIPTION
## Contribution type
- [no] Benchmark coverage extension
- [no] Leaderboard contribution
- [yes] Software change
- [no] Mixed

## Summary
I changed the variable types saved in the metrics folders from int64 to int32, and for floats, I kept a .2f precision. The purpose is to avoid the metrics.py script being killed when there are a large number of episode CSV files.

## Checklist
- [yes] I placed new files in the appropriate directory
- [yes] I ensured that changes are made consistent with the existing benchmark structure
- [N/A] I updated relevant documentation if needed
- [yes] I kept the PR scope focused
- [yes] I described the purpose of this PR clearly